### PR TITLE
Add OpenStack driver to management VMs

### DIFF
--- a/cloud-driver/drivers/config/ConfigHandler.go
+++ b/cloud-driver/drivers/config/ConfigHandler.go
@@ -1,4 +1,4 @@
-package resources
+package config
 
 import (
 	"github.com/gophercloud/gophercloud"
@@ -28,6 +28,7 @@ type Config struct {
 }
 
 func ReadConfigFile() Config {
+	// Set Environment Value of Project Root Path
 	rootPath := os.Getenv("CBSPIDER_PATH")
 	data, err := ioutil.ReadFile(rootPath + "/config/config.yaml")
 	if err != nil {

--- a/cloud-driver/drivers/openstack/OpenStackDriver.go
+++ b/cloud-driver/drivers/openstack/OpenStackDriver.go
@@ -1,0 +1,47 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package openstack
+
+import (
+	"C"
+	oscon "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack/connect"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	icon "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/connect"
+)
+
+
+type OpenStackDriver struct{}
+
+func (OpenStackDriver) GetDriverVersion() string {
+	return "OPENSTACK DRIVER Version 1.0"
+}
+
+func (OpenStackDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
+	var drvCapabilityInfo idrv.DriverCapabilityInfo
+	drvCapabilityInfo.VNetworkHandler = false
+
+	return drvCapabilityInfo
+}
+
+func (OpenStackDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error){
+	// 1. get info of credential and region for Test A Cloud from connectionInfo.
+	// 2. create a client object(or service  object) of Test A Cloud with credential info.
+	// 3. create CloudConnection Instance of "connect/TDA_CloudConnection".
+	// 4. return CloudConnection Interface of TDA_CloudConnection.
+
+	// sample code, do not user like this^^
+	var iConn icon.CloudConnection
+	iConn = oscon.OpenStackCloudConnection{}
+
+	return iConn, nil // return type: (icon.CloudConnection, error)
+}
+
+var TestDriver OpenStackDriver

--- a/cloud-driver/drivers/openstack/OpenStackDriver.go
+++ b/cloud-driver/drivers/openstack/OpenStackDriver.go
@@ -11,12 +11,10 @@
 package openstack
 
 import (
-	"C"
 	oscon "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack/connect"
 	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
 	icon "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/connect"
 )
-
 
 type OpenStackDriver struct{}
 
@@ -31,7 +29,7 @@ func (OpenStackDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	return drvCapabilityInfo
 }
 
-func (OpenStackDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error){
+func (OpenStackDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	// 1. get info of credential and region for Test A Cloud from connectionInfo.
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
 	// 3. create CloudConnection Instance of "connect/TDA_CloudConnection".

--- a/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -8,12 +8,12 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package connect
 
 import (
 	"fmt"
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+	osrs "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack/resources"
 )
 
 type OpenStackCloudConnection struct{}
@@ -22,7 +22,6 @@ func (OpenStackCloudConnection) CreateVNetworkHandler() (irs.VNetworkHandler, er
 	fmt.Println("OpenStack Cloud Driver: called CreateVNetworkHandler()!")
 	return nil, nil
 }
-
 
 func (OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
 	return nil, nil
@@ -42,7 +41,9 @@ func (OpenStackCloudConnection) CreatePublicIPHandler() (irs.PublicIPHandler, er
 }
 
 func (OpenStackCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
-	return nil, nil
+	var vmHandler irs.VMHandler
+	vmHandler = osrs.OpenStackVMHandler{}
+	return vmHandler, nil
 }
 
 func (OpenStackCloudConnection) IsConnected() (bool, error) {
@@ -51,4 +52,3 @@ func (OpenStackCloudConnection) IsConnected() (bool, error) {
 func (OpenStackCloudConnection) Close() error {
 	return nil
 }
-

--- a/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -1,0 +1,54 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+
+package connect
+
+import (
+	"fmt"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type OpenStackCloudConnection struct{}
+
+func (OpenStackCloudConnection) CreateVNetworkHandler() (irs.VNetworkHandler, error) {
+	fmt.Println("OpenStack Cloud Driver: called CreateVNetworkHandler()!")
+	return nil, nil
+}
+
+
+func (OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
+	return nil, nil
+}
+
+func (OpenStackCloudConnection) CreateSecurityHandler() (irs.SecurityHandler, error) {
+	return nil, nil
+}
+func (OpenStackCloudConnection) CreateKeyPairHandler() (irs.KeyPairHandler, error) {
+	return nil, nil
+}
+func (OpenStackCloudConnection) CreateVNicHandler() (irs.VNicHandler, error) {
+	return nil, nil
+}
+func (OpenStackCloudConnection) CreatePublicIPHandler() (irs.PublicIPHandler, error) {
+	return nil, nil
+}
+
+func (OpenStackCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
+	return nil, nil
+}
+
+func (OpenStackCloudConnection) IsConnected() (bool, error) {
+	return true, nil
+}
+func (OpenStackCloudConnection) Close() error {
+	return nil
+}
+

--- a/cloud-driver/drivers/openstack/main/Test.go
+++ b/cloud-driver/drivers/openstack/main/Test.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"fmt"
+	config "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/config"
 	osdrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack"
-	osrs "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack/resources"
 	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
 )
 
 // Test OpenStack Connection
 func TestConnection() {
-	client, err := osrs.GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -29,7 +29,7 @@ func TestVMHandler() {
 		panic(err)
 	}
 
-	config := osrs.ReadConfigFile()
+	config := config.ReadConfigFile()
 
 	// Get VM List
 	vmList := vmHandler.ListVM()
@@ -64,7 +64,7 @@ func CreateVM() {
 		panic(err)
 	}
 
-	config := osrs.ReadConfigFile()
+	config := config.ReadConfigFile()
 
 	// Create VM Server
 	vmReqInfo := irs.VMReqInfo{
@@ -99,7 +99,7 @@ func HandleVM() {
 	fmt.Println("3. Reboot VM")
 	fmt.Println("4. Terminate VM")
 
-	config := osrs.ReadConfigFile()
+	config := config.ReadConfigFile()
 
 	var cloudDriver idrv.CloudDriver
 	cloudDriver = new(osdrv.OpenStackDriver)

--- a/cloud-driver/drivers/openstack/main/Test.go
+++ b/cloud-driver/drivers/openstack/main/Test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	osdrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack"
+	osrs "github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/openstack/resources"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+func TestConnection() {
+	client, err := osrs.GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(client)
+}
+
+func TestVMHandler() {
+	var cloudDriver idrv.CloudDriver
+	cloudDriver = new(osdrv.OpenStackDriver)
+
+	connectionInfo := idrv.ConnectionInfo{}
+	cloudConnection, _ := cloudDriver.ConnectCloud(connectionInfo)
+	vmHandler, err := cloudConnection.CreateVMHandler()
+	if err != nil {
+		panic(err)
+	}
+
+	config := osrs.ReadConfigFile()
+
+	// Get VM List
+	vmList := vmHandler.ListVM()
+	for i, vm := range vmList {
+		fmt.Println("[",i,"] ",*vm)
+	}
+
+	// Get VM Info
+	vmInfo := vmHandler.GetVM(config.Openstack.ServerId)
+	fmt.Println(vmInfo)
+}
+
+func CreateVM() {
+	var cloudDriver idrv.CloudDriver
+	cloudDriver = new(osdrv.OpenStackDriver)
+
+	connectionInfo := idrv.ConnectionInfo{}
+	cloudConnection, _ := cloudDriver.ConnectCloud(connectionInfo)
+	vmHandler, err := cloudConnection.CreateVMHandler()
+	if err != nil {
+		panic(err)
+	}
+
+	config := osrs.ReadConfigFile()
+
+	// Create VM Server
+	vmReqInfo := irs.VMReqInfo{
+		Name: config.Openstack.VMName,
+		ImageInfo: irs.ImageInfo{
+			Id: config.Openstack.ImageId,
+		},
+		SpecID: config.Openstack.FlavorId,
+		VNetworkInfo: irs.VNetworkInfo{
+			Id: config.Openstack.NetworkId,
+		},
+		SecurityInfo: irs.SecurityInfo{
+			Name: config.Openstack.SecurityGroups,
+		},
+		KeyPairInfo: irs.KeyPairInfo{
+			Name: config.Openstack.KeypairName,
+		},
+	}
+	createdVM, err := vmHandler.StartVM(vmReqInfo)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("VM_ID=", createdVM.Id)
+}
+
+func HandleVM() {
+
+	fmt.Println("VM LifeCycle Management")
+	fmt.Println("1. Suspend VM")
+	fmt.Println("2. Resume VM")
+	fmt.Println("3. Reboot VM")
+	fmt.Println("4. Terminate VM")
+
+	config := osrs.ReadConfigFile()
+
+	var cloudDriver idrv.CloudDriver
+	cloudDriver = new(osdrv.OpenStackDriver)
+
+	connectionInfo := idrv.ConnectionInfo{}
+	cloudConnection, _ := cloudDriver.ConnectCloud(connectionInfo)
+	vmHandler, err := cloudConnection.CreateVMHandler()
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			panic(err)
+		}
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 1:
+				vmHandler.SuspendVM(config.Openstack.ServerId)
+			case 2:
+				vmHandler.ResumeVM(config.Openstack.ServerId)
+			case 3:
+				vmHandler.RebootVM(config.Openstack.ServerId)
+			case 4:
+				vmHandler.TerminateVM(config.Openstack.ServerId)
+			}
+		}
+	}
+}
+
+func main() {
+	//TestConnection()
+	//TestVMHandler()
+	//CreateVM()
+	HandleVM()
+}

--- a/cloud-driver/drivers/openstack/main/Test.go
+++ b/cloud-driver/drivers/openstack/main/Test.go
@@ -8,6 +8,7 @@ import (
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
 )
 
+// Test OpenStack Connection
 func TestConnection() {
 	client, err := osrs.GetServiceClient()
 	if err != nil {
@@ -16,6 +17,7 @@ func TestConnection() {
 	fmt.Println(client)
 }
 
+// Test VM Handler Functions (Get VM Info, VM Status)
 func TestVMHandler() {
 	var cloudDriver idrv.CloudDriver
 	cloudDriver = new(osdrv.OpenStackDriver)
@@ -38,8 +40,19 @@ func TestVMHandler() {
 	// Get VM Info
 	vmInfo := vmHandler.GetVM(config.Openstack.ServerId)
 	fmt.Println(vmInfo)
+
+	// Get VM Status List
+	vmStatusList := vmHandler.ListVMStatus()
+	for i, vmStatus := range vmStatusList {
+		fmt.Println("[",i,"] ",*vmStatus)
+	}
+
+	// Get VM Status
+	vmStatus := vmHandler.GetVMStatus(config.Openstack.ServerId)
+	fmt.Println(vmStatus)
 }
 
+// Test VM Deployment
 func CreateVM() {
 	var cloudDriver idrv.CloudDriver
 	cloudDriver = new(osdrv.OpenStackDriver)
@@ -77,6 +90,7 @@ func CreateVM() {
 	fmt.Println("VM_ID=", createdVM.Id)
 }
 
+// Test VM Lifecycle Management (Suspend/Resume/Reboot/Terminate)
 func HandleVM() {
 
 	fmt.Println("VM LifeCycle Management")
@@ -120,8 +134,8 @@ func HandleVM() {
 }
 
 func main() {
-	//TestConnection()
-	//TestVMHandler()
+	TestConnection()
+	TestVMHandler()
 	//CreateVM()
-	HandleVM()
+	//HandleVM()
 }

--- a/cloud-driver/drivers/openstack/resources/ConfigHandler.go
+++ b/cloud-driver/drivers/openstack/resources/ConfigHandler.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+	"os"
+)
+
+type Config struct {
+	Openstack struct {
+		DomainName       string `yaml:"domain_name"`
+		IdentityEndpoint string `yaml:"identity_endpoint"`
+		Password         string `yaml:"password"`
+		ProjectID        string `yaml:"project_id"`
+		Username         string `yaml:"username"`
+		Region           string `yaml:"region"`
+		VMName           string `yaml:"vm_name"`
+		ImageId          string `yaml:"image_id"`
+		FlavorId         string `yaml:"flavor_id"`
+		NetworkId        string `yaml:"network_id"`
+		SecurityGroups   string `yaml:"security_groups"`
+		KeypairName      string `yaml:"keypair_name"`
+
+		ServerId string `yaml:"server_id"`
+	} `yaml:"openstack"`
+}
+
+func ReadConfigFile() Config {
+	rootPath := os.Getenv("CBSPIDER_PATH")
+	data, err := ioutil.ReadFile(rootPath + "/config/config.yaml")
+	if err != nil {
+		panic(err)
+	}
+
+	var config Config
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		panic(err)
+	}
+
+	return config
+}
+
+func GetServiceClient() (*gophercloud.ServiceClient, error) {
+
+	// read configuration YAML file
+	config := ReadConfigFile()
+
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: config.Openstack.IdentityEndpoint,
+		Username:         config.Openstack.Username,
+		Password:         config.Openstack.Password,
+		DomainName:       config.Openstack.DomainName,
+		Scope: &gophercloud.AuthScope{
+			ProjectID: config.Openstack.ProjectID,
+		},
+	}
+
+	provider, err := openstack.AuthenticatedClient(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: config.Openstack.Region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, err
+}

--- a/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -1,0 +1,205 @@
+package resources
+
+import (
+	"fmt"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type OpenStackVMHandler struct{}
+
+func (OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
+	client, err := GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	// Add Server Create Options
+	serverCreateOpts := servers.CreateOpts{
+		Name:      vmReqInfo.Name,
+		ImageRef:  vmReqInfo.ImageInfo.Id,
+		FlavorRef: vmReqInfo.SpecID,
+		Networks: []servers.Network{
+			{UUID: vmReqInfo.VNetworkInfo.Id},
+		},
+		SecurityGroups: []string{
+			vmReqInfo.SecurityInfo.Name,
+		},
+		ServiceClient: client,
+	}
+
+	// Add KeyPair
+	createOpts := keypairs.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		KeyName:           vmReqInfo.KeyPairInfo.Name,
+	}
+
+	server, err := servers.Create(client, createOpts).Extract()
+	if err != nil {
+		return irs.VMInfo{}, err
+	}
+
+	vmInfo := MappingServerInfo(*server)
+	return vmInfo, nil
+}
+
+func (OpenStackVMHandler) SuspendVM(vmID string) {
+	client, err := GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	err = startstop.Stop(client, vmID).Err
+}
+
+func (OpenStackVMHandler) ResumeVM(vmID string) {
+	client, err := GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	err = startstop.Start(client, vmID).Err
+}
+
+func (OpenStackVMHandler) RebootVM(vmID string) {
+	client, err := GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	rebootOpts := servers.RebootOpts{
+		Type: servers.SoftReboot,
+		//Type: servers.HardReboot,
+	}
+	err = servers.Reboot(client, vmID, rebootOpts).ExtractErr()
+}
+
+func (OpenStackVMHandler) TerminateVM(vmID string) {
+	client, err := GetServiceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	err = servers.Delete(client, vmID).ExtractErr()
+}
+
+func (OpenStackVMHandler) ListVMStatus() []*irs.VMStatus {
+	client, err := GetServiceClient()
+	if err != nil {
+		return nil
+	}
+
+	var vmStatusList []*irs.VMStatus
+
+	pager := servers.List(client, nil)
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+		// Get VM Status
+		list, err := servers.ExtractServers(page)
+		if err != nil {
+			return false, err
+		}
+		// Add to List
+		for _, s := range list {
+			vmStatus := irs.VMStatus(s.Status)
+			vmStatusList = append(vmStatusList, &vmStatus)
+		}
+		return true, nil
+	})
+
+	return vmStatusList
+}
+
+func (OpenStackVMHandler) GetVMStatus(vmID string) irs.VMStatus {
+	client, err := GetServiceClient()
+	if err != nil {
+		return irs.VMStatus("")
+	}
+
+	serverResult, err := servers.Get(client, vmID).Extract()
+	if err != nil {
+		return irs.VMStatus("")
+	}
+
+	return irs.VMStatus(serverResult.Status)
+}
+
+func (OpenStackVMHandler) ListVM() []*irs.VMInfo {
+	client, err := GetServiceClient()
+	if err != nil {
+		return nil
+	}
+
+	var vmList []*irs.VMInfo
+
+	pager := servers.List(client, nil)
+	err = pager.EachPage(func(page pagination.Page) (bool, error) {
+		// Get Servers
+		list, err := servers.ExtractServers(page)
+		if err != nil {
+			return false, err
+		}
+		// Add to List
+		for _, s := range list {
+			vmInfo := MappingServerInfo(s)
+			vmList = append(vmList, &vmInfo)
+		}
+
+		return true, nil
+	})
+
+	return vmList
+}
+
+func (OpenStackVMHandler) GetVM(vmID string) irs.VMInfo {
+	client, err := GetServiceClient()
+	if err != nil {
+		return irs.VMInfo{}
+	}
+
+	serverResult, err := servers.Get(client, vmID).Extract()
+	if err != nil {
+		fmt.Println(err)
+		return irs.VMInfo{}
+	}
+
+	vmInfo := MappingServerInfo(*serverResult)
+
+	return vmInfo
+}
+
+func MappingServerInfo(server servers.Server) irs.VMInfo {
+
+	// Get Default VM Info
+	vmInfo := irs.VMInfo{
+		Name:      server.Name,
+		Id:        server.ID,
+		StartTime: server.Updated,
+		//ImageID:   server.Image["id"].(string),
+		//SpecID:    server.Flavor["id"].(string),
+	}
+
+	if len(server.Image) != 0 {
+		vmInfo.ImageID = server.Image["id"].(string)
+	}
+	if len(server.Flavor) != 0 {
+		vmInfo.SpecID = server.Flavor["id"].(string)
+	}
+
+	// Get VM Subnet, Address Info
+	for k, subnet := range server.Addresses {
+		vmInfo.SubNetworkID = k
+		for _, addr := range subnet.([]interface{}) {
+			addrMap := addr.(map[string]interface{})
+			if addrMap["OS-EXT-IPS:type"] == "floating" {
+				vmInfo.PrivateIP = addrMap["addr"].(string)
+			} else if addrMap["OS-EXT-IPS:type"] == "fixed" {
+				vmInfo.PublicIP = addrMap["addr"].(string)
+			}
+		}
+	}
+
+	return vmInfo
+}

--- a/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"github.com/cloud-barista/poc-cb-spider/cloud-driver/drivers/config"
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
@@ -12,7 +13,7 @@ import (
 type OpenStackVMHandler struct{}
 
 func (OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +48,7 @@ func (OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
 }
 
 func (OpenStackVMHandler) SuspendVM(vmID string) {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -56,7 +57,7 @@ func (OpenStackVMHandler) SuspendVM(vmID string) {
 }
 
 func (OpenStackVMHandler) ResumeVM(vmID string) {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +66,7 @@ func (OpenStackVMHandler) ResumeVM(vmID string) {
 }
 
 func (OpenStackVMHandler) RebootVM(vmID string) {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +79,7 @@ func (OpenStackVMHandler) RebootVM(vmID string) {
 }
 
 func (OpenStackVMHandler) TerminateVM(vmID string) {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +88,7 @@ func (OpenStackVMHandler) TerminateVM(vmID string) {
 }
 
 func (OpenStackVMHandler) ListVMStatus() []*irs.VMStatus {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		return nil
 	}
@@ -113,7 +114,7 @@ func (OpenStackVMHandler) ListVMStatus() []*irs.VMStatus {
 }
 
 func (OpenStackVMHandler) GetVMStatus(vmID string) irs.VMStatus {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		return irs.VMStatus("")
 	}
@@ -127,7 +128,7 @@ func (OpenStackVMHandler) GetVMStatus(vmID string) irs.VMStatus {
 }
 
 func (OpenStackVMHandler) ListVM() []*irs.VMInfo {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		return nil
 	}
@@ -154,7 +155,7 @@ func (OpenStackVMHandler) ListVM() []*irs.VMInfo {
 }
 
 func (OpenStackVMHandler) GetVM(vmID string) irs.VMInfo {
-	client, err := GetServiceClient()
+	client, err := config.GetServiceClient()
 	if err != nil {
 		return irs.VMInfo{}
 	}

--- a/cloud-driver/interfaces/resources/ImageHandler.go
+++ b/cloud-driver/interfaces/resources/ImageHandler.go
@@ -8,8 +8,8 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package resources
+
 //package image
 
 type ImageReqInfo struct {
@@ -18,11 +18,10 @@ type ImageReqInfo struct {
 }
 
 type ImageInfo struct {
-	name string
-	id string
+	Name string
+	Id   string
 	// @todo
 }
-
 
 type ImageHandler interface {
 	CreateImage(imageReqInfo ImageReqInfo) (ImageInfo, error)
@@ -30,4 +29,3 @@ type ImageHandler interface {
 	GetImage(imageID string) (ImageInfo, error)
 	DeleteImage(imageID string) (bool, error)
 }
-

--- a/cloud-driver/interfaces/resources/KeyPairHandler.go
+++ b/cloud-driver/interfaces/resources/KeyPairHandler.go
@@ -8,18 +8,17 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package resources
 
 type KeyPairReqInfo struct {
 	name string
-        // @todo
+	// @todo
 }
 
 type KeyPairInfo struct {
-	name string
-	id string
-        // @todo
+	Name string
+	Id   string
+	// @todo
 }
 
 type KeyPairHandler interface {
@@ -28,4 +27,3 @@ type KeyPairHandler interface {
 	GetKey(keyPairID string) (KeyPairInfo, error)
 	DeleteKey(keyPairID string) (bool, error)
 }
-

--- a/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -8,18 +8,17 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package resources
 
 type SecurityReqInfo struct {
 	name string
-        // @todo
+	// @todo
 }
 
 type SecurityInfo struct {
-	name string
-	id string
-        // @todo
+	Name string
+	Id   string
+	// @todo
 }
 
 type SecurityHandler interface {
@@ -28,4 +27,3 @@ type SecurityHandler interface {
 	GetSecurity(securityID string) (SecurityInfo, error)
 	DeleteSecurity(securityID string) (bool, error)
 }
-

--- a/cloud-driver/interfaces/resources/VMHandler.go
+++ b/cloud-driver/interfaces/resources/VMHandler.go
@@ -8,7 +8,6 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package resources
 
 import (
@@ -18,77 +17,76 @@ import (
 type VMReqInfo struct {
 	// region/zone: Do not specify, this driver already knew these in Connection.
 
-	name string
+	Name string
 
-	imageInfo ImageInfo 
-	vNetworkInfo VNetworkInfo
-	securityInfo SecurityInfo
-	keyPairInfo KeyPairInfo
-	specID string 	// instance type or flavour, etc...
-	vNicInfo VNicInfo
-	publicIPInfo PublicIPInfo
+	ImageInfo    ImageInfo
+	VNetworkInfo VNetworkInfo
+	SecurityInfo SecurityInfo
+	KeyPairInfo  KeyPairInfo
+	SpecID       string // instance type or flavour, etc...
+	vNicInfo     VNicInfo
+	PublicIPInfo PublicIPInfo
 }
 
-// GO do not support Enum. So, define like this. 
+// GO do not support Enum. So, define like this.
 type VMStatus string
+
 const (
-        pending VMStatus = "PENDING" 		// from launch, suspended to running
-        running VMStatus = "RUNNING"
+	pending VMStatus = "PENDING" // from launch, suspended to running
+	running VMStatus = "RUNNING"
 
-        suspending VMStatus = "SUSPENDING"	// from running to suspended
-	suspended VMStatus = "SUSPENDED"
+	suspending VMStatus = "SUSPENDING" // from running to suspended
+	suspended  VMStatus = "SUSPENDED"
 
-        rebooting VMStatus = "REBOOTING"	// from running to running
+	rebooting VMStatus = "REBOOTING" // from running to running
 
-        termiating VMStatus = "TERMINATING"	// from running, suspended to terminated
-        termiated VMStatus = "TERMINATED"
+	termiating VMStatus = "TERMINATING" // from running, suspended to terminated
+	termiated  VMStatus = "TERMINATED"
 )
 
 type RegionInfo struct {
-        region string
-        zone string
+	Region string
+	Zone   string
 }
 
 type VMInfo struct {
-	name string
-	id string
-	startTime time.Time 	// Timezone: based on cloud-barista server location.
-	
-	region RegionInfo		// ex) {us-east1, us-east1-c} or {ap-northeast-2}
-	imageID string		// ex) ami-047f7b46bd6dd5d84 or projects/gce-uefi-images/global/images/centos-7-v20190326
-	specID string 		// instance type or flavour, etc... ex) t2.micro or f1-micro
-	vNetworkID string 	// ex) vpc-23ed0a4b
-	subNetworkID string	// ex) subnet-8c4a53e4
-	securityID string	// ex) sg-0b7452563e1121bb6
-	
-	vNIC string		// ex) eth0
-	publicIP string		// ex) 13.125.43.21 
-	publicDNS string	// ex) ec2-13-125-43-0.ap-northeast-2.compute.amazonaws.com
-	privateIP string	// ex) ip-172-31-4-60.ap-northeast-2.compute.internal
-	privateDNS string	// ex) 172.31.4.60
-	
-	keyPairID string	// ex) powerkimKeyPair
-	guestUserID string	// ex) user1
-	guestUserPwd string	
+	Name      string
+	Id        string
+	StartTime time.Time // Timezone: based on cloud-barista server location.
 
-	guestBootDisk string	// ex) /dev/sda1
-	guestBlockDisk string	// ex) 
+	Region       RegionInfo // ex) {us-east1, us-east1-c} or {ap-northeast-2}
+	ImageID      string     // ex) ami-047f7b46bd6dd5d84 or projects/gce-uefi-images/global/images/centos-7-v20190326
+	SpecID       string     // instance type or flavour, etc... ex) t2.micro or f1-micro
+	VNetworkID   string     // ex) vpc-23ed0a4b
+	SubNetworkID string     // ex) subnet-8c4a53e4
+	SecurityID   string     // ex) sg-0b7452563e1121bb6
 
-	additionalInfo string // Any information to be good for users and developers.
+	VNIC       string // ex) eth0
+	PublicIP   string // ex) 13.125.43.21
+	PublicDNS  string // ex) ec2-13-125-43-0.ap-northeast-2.compute.amazonaws.com
+	PrivateIP  string // ex) ip-172-31-4-60.ap-northeast-2.compute.internal
+	PrivateDNS string // ex) 172.31.4.60
+
+	KeyPairID    string // ex) powerkimKeyPair
+	GuestUserID  string // ex) user1
+	GuestUserPwd string
+
+	GuestBootDisk  string // ex) /dev/sda1
+	GuestBlockDisk string // ex)
+
+	AdditionalInfo string // Any information to be good for users and developers.
 }
 
 type VMHandler interface {
-
 	StartVM(vmReqInfo VMReqInfo) (VMInfo, error)
 	SuspendVM(vmID string)
 	ResumeVM(vmID string)
 	RebootVM(vmID string)
 	TerminateVM(vmID string)
 
-	ListVMStatus() []*VMStatus 
-	GetVMStatus(vmID string) VMStatus 
+	ListVMStatus() []*VMStatus
+	GetVMStatus(vmID string) VMStatus
 
-	ListVM() []*VMInfo 
+	ListVM() []*VMInfo
 	GetVM(vmID string) VMInfo
 }
-

--- a/cloud-driver/interfaces/resources/VNetworkHandler.go
+++ b/cloud-driver/interfaces/resources/VNetworkHandler.go
@@ -8,24 +8,22 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
-
 package resources
 
 type VNetworkReqInfo struct {
 	name string
-        // @todo
+	// @todo
 }
 
 type VNetworkInfo struct {
-	name string
-	id string
-        // @todo
+	Name string
+	Id   string
+	// @todo
 }
 
 type VNetworkHandler interface {
 	CreateVNetwork(vNetworkReqInfo VNetworkReqInfo) (VNetworkInfo, error)
 	ListVNetwork() ([]*VNetworkInfo, error)
-	GetVNetwork(vNetworkID string) (VNetworkInfo, error) 
+	GetVNetwork(vNetworkID string) (VNetworkInfo, error)
 	DeleteVNetwork(vNetworkID string) (bool, error)
 }
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,32 @@
+#### Config for CB-Spider PoC ####
+
+## Config for OpenStack ##
+
+#openstack:
+#  domain_name: {domain_name}
+#  identity_endpoint: http://{ip}:5000/v3
+#  password: {password}
+#  project_id: {project_id}
+#  username: {username}
+#  region: {region}
+
+openstack:
+
+  # OpenStack Credential Info
+  domain_name: {domain_name}
+  identity_endpoint: http://{ip}:5000/v3
+  password: {password}
+  project_id: {project_id}
+  username: {username}
+  region: {region}
+
+  # OpenStack VM Deployment Info
+  vm_name: mcb-test-vm
+  image_id: 3da11509-cf77-4101-a946-3ab8d4554dd0
+  flavor_id: 2
+  network_id: b0774ac8-3124-4d62-a07a-5cf32f6e3567
+  security_groups: test-sg
+  keypair_name: mcb-key
+
+  # OpenStack Test VM Info
+  server_id: 91c7546b-ad1e-4ce3-963d-099ad96145ba


### PR DESCRIPTION
This PR is to Add OpenStack driver to management VMs.

OpenStack driver read configuration file in project path with name **'config.yaml'**
you need to set environments  variable as **CBSPIDER_PATH**
you can test OpenStack drivers in Test.go file.

