### PR TITLE
0.5버전 반영

### DIFF
--- a/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-driver/drivers/aws/AwsDriver.go
@@ -37,7 +37,7 @@ func (AwsDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.ImageHandler = false
 	drvCapabilityInfo.VNetworkHandler = false
 	drvCapabilityInfo.SecurityHandler = false
-	drvCapabilityInfo.KeyPairHandler = false
+	drvCapabilityInfo.KeyPairHandler = true
 	drvCapabilityInfo.VNicHandler = false
 	drvCapabilityInfo.PublicIPHandler = false
 	drvCapabilityInfo.VMHandler = true
@@ -86,7 +86,14 @@ func (driver *AwsDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 		Region:        connectionInfo.RegionInfo,
 		VMClient:      vmClient,
 		KeyPairClient: vmClient,
+
+		VNetworkClient: vmClient,
+		VNicClient:     vmClient,
+		ImageClient:    vmClient,
+		PublicIPClient: vmClient,
+		SecurityClient: vmClient,
 	}
+
 	return &iConn, nil // return type: (icon.CloudConnection, error)
 }
 

--- a/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -11,8 +11,6 @@
 package connect
 
 import (
-	"fmt"
-
 	cblog "github.com/cloud-barista/cb-log"
 	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
@@ -44,32 +42,12 @@ func init() {
 	cblogger = cblog.GetLogger("AWS Connect")
 }
 
-func (cloudConn *AwsCloudConnection) CreateVNetworkHandler() (irs.VNetworkHandler, error) {
-	fmt.Println("TEST AWS Cloud Driver: called CreateVNetworkHandler()!")
-	return nil, nil
-}
-
-func (cloudConn *AwsCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
-	return nil, nil
-}
-
-func (cloudConn *AwsCloudConnection) CreateSecurityHandler() (irs.SecurityHandler, error) {
-	return nil, nil
-}
-
 func (cloudConn *AwsCloudConnection) CreateKeyPairHandler() (irs.KeyPairHandler, error) {
 	cblogger.Info("Start CreateKeyPairHandler()")
 
 	keyPairHandler := ars.AwsKeyPairHandler{cloudConn.Region, cloudConn.KeyPairClient}
 
 	return &keyPairHandler, nil
-}
-
-func (cloudConn *AwsCloudConnection) CreateVNicHandler() (irs.VNicHandler, error) {
-	return nil, nil
-}
-func (cloudConn *AwsCloudConnection) CreatePublicIPHandler() (irs.PublicIPHandler, error) {
-	return nil, nil
 }
 
 func (cloudConn *AwsCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
@@ -86,7 +64,6 @@ func (cloudConn *AwsCloudConnection) Close() error {
 	return nil
 }
 
-/*
 func (cloudConn *AwsCloudConnection) CreateVNetworkHandler() (irs.VNetworkHandler, error) {
 	cblogger.Info("Start")
 	handler := ars.AwsVNetworkHandler{cloudConn.Region, cloudConn.KeyPairClient}
@@ -120,4 +97,3 @@ func (cloudConn *AwsCloudConnection) CreatePublicIPHandler() (irs.PublicIPHandle
 
 	return &handler, nil
 }
-*/

--- a/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -29,6 +29,12 @@ type AwsCloudConnection struct {
 	Region        idrv.RegionInfo
 	KeyPairClient *ec2.EC2
 	VMClient      *ec2.EC2
+
+	VNetworkClient *ec2.EC2
+	VNicClient     *ec2.EC2
+	ImageClient    *ec2.EC2
+	PublicIPClient *ec2.EC2
+	SecurityClient *ec2.EC2
 }
 
 var cblogger *logrus.Logger
@@ -79,3 +85,39 @@ func (cloudConn *AwsCloudConnection) IsConnected() (bool, error) {
 func (cloudConn *AwsCloudConnection) Close() error {
 	return nil
 }
+
+/*
+func (cloudConn *AwsCloudConnection) CreateVNetworkHandler() (irs.VNetworkHandler, error) {
+	cblogger.Info("Start")
+	handler := ars.AwsVNetworkHandler{cloudConn.Region, cloudConn.KeyPairClient}
+
+	return &handler, nil
+}
+
+func (cloudConn *AwsCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
+	cblogger.Info("Start")
+	handler := ars.AwsImageHandler{cloudConn.Region, cloudConn.KeyPairClient}
+
+	return &handler, nil
+}
+
+func (cloudConn *AwsCloudConnection) CreateSecurityHandler() (irs.SecurityHandler, error) {
+	cblogger.Info("Start")
+	handler := ars.AwsSecurityHandler{cloudConn.Region, cloudConn.KeyPairClient}
+
+	return &handler, nil
+}
+
+func (cloudConn *AwsCloudConnection) CreateVNicHandler() (irs.VNicHandler, error) {
+	cblogger.Info("Start")
+	handler := ars.AwsVNicHandler{cloudConn.Region, cloudConn.KeyPairClient}
+
+	return &handler, nil
+}
+func (cloudConn *AwsCloudConnection) CreatePublicIPHandler() (irs.PublicIPHandler, error) {
+	cblogger.Info("Start")
+	handler := ars.AwsPublicIPHandler{cloudConn.Region, cloudConn.KeyPairClient}
+
+	return &handler, nil
+}
+*/

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -33,7 +33,7 @@ func init() {
 	cblog.SetLevel("debug")
 }
 
-// Test VM Lifecycle Management (Create/Suspend/Resume/Reboot/Terminate)
+// Test KeyPair
 func handleKeyPair() {
 	cblogger.Debug("Start KeyPair Resource Test")
 
@@ -68,7 +68,7 @@ func handleKeyPair() {
 			case 1:
 				result, err := KeyPairHandler.ListKey()
 				if err != nil {
-					cblogger.Infof(keyPairName, " 키 페어 목록 조회 실패 : ", err)
+					cblogger.Infof(" 키 페어 목록 조회 실패 : ", err)
 				} else {
 					cblogger.Info("키 페어 목록 조회 결과")
 					//cblogger.Info(result)
@@ -107,9 +107,80 @@ func handleKeyPair() {
 	}
 }
 
+// Test KeyPair
+func handleVNetwork() {
+	cblogger.Debug("Start KeyPair Resource Test")
+
+	vNetworkHandler, err := setVNetworkHandler()
+	if err != nil {
+		panic(err)
+	}
+
+	keyId := "test123"
+
+	for {
+		fmt.Println("VNetworkHandler Management")
+		fmt.Println("0. Quit")
+		fmt.Println("1. VNetwork List")
+		fmt.Println("2. VNetwork Create")
+		fmt.Println("3. VNetwork Get")
+		fmt.Println("4. VNetwork Delete")
+
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			panic(err)
+		}
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 0:
+				return
+
+			case 1:
+				result, err := vNetworkHandler.ListVNetwork()
+				if err != nil {
+					cblogger.Infof(" VNetwork 목록 조회 실패 : ", err)
+				} else {
+					cblogger.Info("VNetwork 목록 조회 결과")
+					//cblogger.Info(result)
+					spew.Dump(result)
+				}
+
+			case 2:
+				cblogger.Infof("[%s] VNetwork 생성 테스트", keyId)
+				vNetworkReqInfo := irs.VNetworkReqInfo{}
+				result, err := vNetworkHandler.CreateVNetwork(vNetworkReqInfo)
+				if err != nil {
+					cblogger.Infof(keyId, " VNetwork 생성 실패 : ", err)
+				} else {
+					cblogger.Infof("VNetwork 생성 결과 : ", result)
+				}
+			case 3:
+				cblogger.Infof("[%s] VNetwork 조회 테스트", keyId)
+				result, err := vNetworkHandler.GetVNetwork(keyId)
+				if err != nil {
+					cblogger.Infof("[%s] VNetwork 조회 실패 : ", keyId, err)
+				} else {
+					cblogger.Infof("[%s] VNetwork 조회 결과 : [%s]", keyId, result)
+				}
+			case 4:
+				cblogger.Infof("[%s] VNetwork 삭제 테스트", keyId)
+				result, err := vNetworkHandler.DeleteVNetwork(keyId)
+				if err != nil {
+					cblogger.Infof("[%s] VNetwork 삭제 실패 : ", keyId, err)
+				} else {
+					cblogger.Infof("[%s] VNetwork 삭제 결과 : [%s]", keyId, result)
+				}
+			}
+		}
+	}
+}
+
 func main() {
 	cblogger.Info("AWS Resource Test")
-	handleKeyPair()
+	//handleKeyPair()
+	handleVNetwork()
 	/*
 		KeyPairHandler, err := setKeyPairHandler()
 		if err != nil {
@@ -153,6 +224,33 @@ func setKeyPairHandler() (irs.KeyPairHandler, error) {
 		return nil, err
 	}
 	return keyPairHandler, nil
+}
+
+func setVNetworkHandler() (irs.VNetworkHandler, error) {
+	var cloudDriver idrv.CloudDriver
+	cloudDriver = new(awsdrv.AwsDriver)
+
+	config := readConfigFile()
+	connectionInfo := idrv.ConnectionInfo{
+		CredentialInfo: idrv.CredentialInfo{
+			ClientId:     config.Aws.AawsAccessKeyID,
+			ClientSecret: config.Aws.AwsSecretAccessKey,
+		},
+		RegionInfo: idrv.RegionInfo{
+			Region: config.Aws.Region,
+		},
+	}
+
+	cloudConnection, err := cloudDriver.ConnectCloud(connectionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	handler, err := cloudConnection.CreateVNetworkHandler()
+	if err != nil {
+		return nil, err
+	}
+	return handler, nil
 }
 
 // Region : 사용할 리전명 (ex) ap-northeast-2

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -179,8 +179,8 @@ func handleVNetwork() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-	//handleKeyPair()
-	handleVNetwork()
+	handleKeyPair()
+	//handleVNetwork()	//VPC
 	/*
 		KeyPairHandler, err := setKeyPairHandler()
 		if err != nil {

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -67,7 +67,7 @@ func handleKeyPair() {
 
 			case 1:
 				result, err := KeyPairHandler.ListKey()
-				if err != nil { ㅠㅕㅠㅐㅍㅍㅍㅍ
+				if err != nil {
 					cblogger.Infof(keyPairName, " 키 페어 목록 조회 실패 : ", err)
 				} else {
 					cblogger.Info("키 페어 목록 조회 결과")
@@ -80,19 +80,28 @@ func handleKeyPair() {
 				keyPairReqInfo := irs.KeyPairReqInfo{
 					Name: keyPairName,
 				}
-				KeyPairHandler.CreateKey(keyPairReqInfo)
+				result, err := KeyPairHandler.CreateKey(keyPairReqInfo)
+				if err != nil {
+					cblogger.Infof(keyPairName, " 키 페어 생성 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] 키 페어 생성 결과 : [%s]", keyPairName, result)
+				}
 			case 3:
 				cblogger.Infof("[%s] 키 페어 조회 테스트", keyPairName)
 				result, err := KeyPairHandler.GetKey(keyPairName)
 				if err != nil {
 					cblogger.Infof(keyPairName, " 키 페어 조회 실패 : ", err)
 				} else {
-					cblogger.Infof("[%s] 키 페어 조회 결과 : [%s]", result)
+					cblogger.Infof("[%s] 키 페어 조회 결과 : [%s]", keyPairName, result)
 				}
 			case 4:
 				cblogger.Infof("[%s] 키 페어 삭제 테스트", keyPairName)
-				result, _ := KeyPairHandler.DeleteKey(keyPairName)
-				cblogger.Infof("[%s] 키 페어 삭제 결과 : [%s]", result)
+				result, err := KeyPairHandler.DeleteKey(keyPairName)
+				if err != nil {
+					cblogger.Infof(keyPairName, " 키 페어 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] 키 페어 삭제 결과 : [%s]", keyPairName, result)
+				}
 			}
 		}
 	}
@@ -100,8 +109,23 @@ func handleKeyPair() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-
 	handleKeyPair()
+	/*
+		KeyPairHandler, err := setKeyPairHandler()
+		if err != nil {
+			panic(err)
+		}
+
+		keyPairName := "test123"
+		cblogger.Infof("[%s] 키 페어 조회 테스트", keyPairName)
+		result, err := KeyPairHandler.GetKey(keyPairName)
+		if err != nil {
+			cblogger.Infof(keyPairName, " 키 페어 조회 실패 : ", err)
+		} else {
+			cblogger.Infof("[%s] 키 페어 조회 결과")
+			spew.Dump(result)
+		}
+	*/
 }
 
 func setKeyPairHandler() (irs.KeyPairHandler, error) {

--- a/cloud-driver/drivers/aws/resources/ImageHandler.go
+++ b/cloud-driver/drivers/aws/resources/ImageHandler.go
@@ -1,0 +1,39 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type AwsImageHandler struct {
+	Region idrv.RegionInfo
+	Client *ec2.EC2
+}
+
+func (imageHandler *AwsImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) (irs.ImageInfo, error) {
+
+	return irs.ImageInfo{}, nil
+}
+
+func (imageHandler *AwsImageHandler) ListImage() ([]*irs.ImageInfo, error) {
+	return nil, nil
+}
+
+func (imageHandler *AwsImageHandler) GetImage(imageID string) (irs.ImageInfo, error) {
+	return irs.ImageInfo{}, nil
+}
+
+func (imageHandler *AwsImageHandler) DeleteImage(imageID string) (bool, error) {
+	return true, nil
+}

--- a/cloud-driver/drivers/aws/resources/PublicIPHandler.go
+++ b/cloud-driver/drivers/aws/resources/PublicIPHandler.go
@@ -1,0 +1,39 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type AwsPublicIPHandler struct {
+	Region idrv.RegionInfo
+	Client *ec2.EC2
+}
+
+func (publicIpHandler *AwsPublicIPHandler) CreatePublicIP(publicIPReqInfo irs.PublicIPReqInfo) (irs.PublicIPInfo, error) {
+
+	return irs.PublicIPInfo{}, nil
+}
+
+func (publicIpHandler *AwsPublicIPHandler) ListPublicIP() ([]*irs.PublicIPInfo, error) {
+	return nil, nil
+}
+
+func (publicIpHandler *AwsPublicIPHandler) GetPublicIP(publicIPID string) (irs.PublicIPInfo, error) {
+	return irs.PublicIPInfo{}, nil
+}
+
+func (publicIpHandler *AwsPublicIPHandler) DeletePublicIP(publicIPID string) (bool, error) {
+	return false, nil
+}

--- a/cloud-driver/drivers/aws/resources/SecurityHandler.go
+++ b/cloud-driver/drivers/aws/resources/SecurityHandler.go
@@ -1,0 +1,38 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type AwsSecurityHandler struct {
+	Region idrv.RegionInfo
+	Client *ec2.EC2
+}
+
+func (securityHandler *AwsSecurityHandler) CreateSecurity(securityReqInfo irs.SecurityReqInfo) (irs.SecurityInfo, error) {
+	return irs.SecurityInfo{}, nil
+}
+
+func (securityHandler *AwsSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, error) {
+	return nil, nil
+}
+
+func (securityHandler *AwsSecurityHandler) GetSecurity(securityID string) (irs.SecurityInfo, error) {
+	return irs.SecurityInfo{}, nil
+}
+
+func (securityHandler *AwsSecurityHandler) DeleteSecurity(securityID string) (bool, error) {
+	return true, nil
+}

--- a/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -8,7 +8,6 @@ package resources
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 
@@ -26,7 +25,6 @@ import (
 
 type AwsVMHandler struct {
 	Region idrv.RegionInfo
-	//Client *ec2drv.EC2
 	Client *ec2.EC2
 }
 
@@ -54,10 +52,11 @@ func Connect(region string) *ec2.EC2 {
 	return svc
 }
 
-// 1개의 VM만 생성되도록 수정 (MinCount / MaxCount 이용 안 함)
 // @Todo : SecurityGroupId 배열 처리 방안
+// 1개의 VM만 생성되도록 수정 (MinCount / MaxCount 이용 안 함)
+//키페어 이름(예:mcloud-barista)은 아래 URL에 나오는 목록 중 "키페어 이름"의 값을 적으면 됨.
+//https://ap-northeast-2.console.aws.amazon.com/ec2/v2/home?region=ap-northeast-2#KeyPairs:sort=keyName
 func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
-	//fmt.Println("Start VMHandler()::StartVM()")
 	cblogger.Info("Start VMHandler()::StartVM()")
 	spew.Dump(vmReqInfo)
 
@@ -71,34 +70,25 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	baseName := vmReqInfo.Name                   //"mcloud-barista-VMHandlerTest"
 
 	cblogger.Info("Create EC2 Instance")
-	//fmt.Println("Create EC2 Instance")
-
-	//키페어 이름(예:mcloud-barista)은 아래 URL에 나오는 목록 중 "키페어 이름"의 값을 적으면 됨.
-	//https://ap-northeast-2.console.aws.amazon.com/ec2/v2/home?region=ap-northeast-2#KeyPairs:sort=keyName
 
 	// Specify the details of the instance that you want to create.
 	runResult, err := vmHandler.Client.RunInstances(&ec2.RunInstancesInput{
-		// An Amazon Linux AMI ID for t2.micro instances in the us-west-2 region
 		ImageId:      aws.String(imageID),
 		InstanceType: aws.String(instanceType),
 		MinCount:     minCount,
 		MaxCount:     maxCount,
-		KeyName:      aws.String(keyName), // set a keypair Name, ex) aws.powerkim.keypair
+		KeyName:      aws.String(keyName),
 		SecurityGroupIds: []*string{
 			aws.String(securityGroupID), // set a security group.
 		},
 		SubnetId: aws.String(subnetID), // set a subnet.
 	})
-
 	if err != nil {
-		//fmt.Println("Could not create instance", err)
 		cblogger.Errorf("Could not create instance", err)
 		return irs.VMInfo{}, err
 	}
 
-	//fmt.Println("Created instance", *runResult.Instances[0].InstanceId)
 	cblogger.Info("Created instance", *runResult.Instances[0].InstanceId)
-
 	// Tag에 VM Name 설정
 	_, errtag := vmHandler.Client.CreateTags(&ec2.CreateTagsInput{
 		Resources: []*string{runResult.Instances[0].InstanceId},
@@ -109,10 +99,9 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			},
 		},
 	})
-
 	if errtag != nil {
-		log.Println("Could not create tags for instance", runResult.Instances[0].InstanceId, errtag)
-		return irs.VMInfo{}, err
+		cblogger.Error("Could not create tags for instance", runResult.Instances[0].InstanceId, errtag)
+		return irs.VMInfo{}, errtag
 	}
 
 	//빠른 생성을 위해 Running 상태를 대기하지 않고 최소한의 정보만 리턴 함.
@@ -124,14 +113,15 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	//cblogger.Info("EC2 Running 상태 완료 : ", runResult.Instances[0].State.Name)
 
 	vmInfo := ExtractDescribeInstances(runResult)
+	//속도상 VM 정보를 다시 조회하지 않았기 때문에 Tag 정보가 누락되어서 Name 정보가 설정되어 있지 않음.
 	if vmInfo.Name == "" {
 		vmInfo.Name = baseName
 	}
 
 	return vmInfo, nil
-	//return irs.VMInfo{}, nil
 }
 
+//VM이 Running 상태일때까지 대기 함.
 func WaitForRun(svc *ec2.EC2, instanceID string) {
 	cblogger.Infof("EC2 ID : [%s]", instanceID)
 
@@ -142,7 +132,6 @@ func WaitForRun(svc *ec2.EC2, instanceID string) {
 	}
 	err := svc.WaitUntilInstanceRunning(input)
 	if err != nil {
-		//fmt.Println("failed to wait until instances exist: %v", err)
 		cblogger.Errorf("failed to wait until instances exist: %v", err)
 	}
 	cblogger.Info("=========WaitForRun() 종료")
@@ -190,15 +179,12 @@ func (vmHandler *AwsVMHandler) SuspendVM(vmID string) {
 		input.DryRun = aws.Bool(false)
 		result, err = vmHandler.Client.StopInstances(input)
 		if err != nil {
-			//fmt.Println("Error", err)
 			cblogger.Error(err)
 		} else {
-			//fmt.Println("Success", result.StoppingInstances)
 			cblogger.Info("Success", result.StoppingInstances)
 		}
 	} else {
-		//fmt.Println("Error", err)
-		cblogger.Error(err)
+		cblogger.Error("Error", err)
 	}
 }
 
@@ -227,14 +213,11 @@ func (vmHandler *AwsVMHandler) RebootVM(vmID string) {
 		cblogger.Info("result 값 : ", result)
 		cblogger.Info("err 값 : ", err)
 		if err != nil {
-			//fmt.Println("Error", err)
-			cblogger.Error(err)
+			cblogger.Error("Error", err)
 		} else {
-			//fmt.Println("Success", result)
 			cblogger.Info("Success", result)
 		}
 	} else { // This could be due to a lack of permissions
-		//fmt.Println("Error", err)
 		cblogger.Info("리부팅 권한이 없는 것같음.")
 		cblogger.Error("Error", err)
 	}
@@ -252,7 +235,6 @@ func (vmHandler *AwsVMHandler) TerminateVM(vmID string) {
 
 	_, err := vmHandler.Client.TerminateInstances(input)
 	if err != nil {
-		//fmt.Println("Could not termiate instances", err)
 		cblogger.Error("Could not termiate instances", err)
 	} else {
 		cblogger.Info("Success")
@@ -260,6 +242,8 @@ func (vmHandler *AwsVMHandler) TerminateVM(vmID string) {
 	return
 }
 
+//- 보안그룹의 경우 멀티개 설정이 가능한데 현재는 1개만 입력 받음
+// @Todo : SecurityID에 보안그룹 Name을 할당하는게 맞는지 확인 필요
 func (vmHandler *AwsVMHandler) GetVM(vmID string) irs.VMInfo {
 	cblogger.Infof("vmID : [%s]", vmID)
 
@@ -274,12 +258,10 @@ func (vmHandler *AwsVMHandler) GetVM(vmID string) irs.VMInfo {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			default:
-				//fmt.Println(aerr.Error())
 				cblogger.Error(aerr.Error())
 			}
 		} else {
 			// Print the error, cast err to awserr.Error to get the Code and Message from an error.
-			//fmt.Println(err.Error())
 			cblogger.Error(err.Error())
 		}
 		return irs.VMInfo{}
@@ -297,36 +279,9 @@ func (vmHandler *AwsVMHandler) GetVM(vmID string) irs.VMInfo {
 		vmInfo = ExtractDescribeInstances(i)
 	}
 
-	/*
-		vmInfo := irs.VMInfo{
-			Name: *result.Reservations[0].Instances[0].Tags[0].Value,
-			Id:   *result.Reservations[0].Instances[0].InstanceId,
-			Region: irs.RegionInfo{
-				Region: *result.Reservations[0].Instances[0].Placement.AvailabilityZone,
-			},
-			ImageID:      *result.Reservations[0].Instances[0].ImageId,
-			SpecID:       *result.Reservations[0].Instances[0].InstanceType,
-			VNetworkID:   *result.Reservations[0].Instances[0].NetworkInterfaces[0].VpcId,
-			SubNetworkID: *result.Reservations[0].Instances[0].NetworkInterfaces[0].SubnetId,
-			SecurityID:   *result.Reservations[0].Instances[0].NetworkInterfaces[0].Groups[0].GroupId,
-			//SecurityName: *result.Reservations[0].Instances[0].NetworkInterfaces[0].Groups[0].GroupName,
-			VNIC:           "eth0 - 값 위치 확인 필요",
-			PublicIP:       *result.Reservations[0].Instances[0].NetworkInterfaces[0].Association.PublicIp,
-			PublicDNS:      *result.Reservations[0].Instances[0].NetworkInterfaces[0].Association.PublicDnsName,
-			PrivateIP:      *result.Reservations[0].Instances[0].NetworkInterfaces[0].PrivateIpAddress,
-			PrivateDNS:     *result.Reservations[0].Instances[0].NetworkInterfaces[0].PrivateDnsName,
-			KeyPairID:      *result.Reservations[0].Instances[0].KeyName,
-			GuestUserID:    "",
-			GuestBootDisk:  *result.Reservations[0].Instances[0].RootDeviceName,
-			GuestBlockDisk: *result.Reservations[0].Instances[0].BlockDeviceMappings[0].DeviceName,
-			AdditionalInfo: "",
-		}
-	*/
-
 	cblogger.Info("vmInfo", vmInfo)
 
 	return vmInfo
-	//return irs.VMInfo{}
 }
 
 // DescribeInstances결과에서 EC2 세부 정보 추출
@@ -335,12 +290,8 @@ func (vmHandler *AwsVMHandler) GetVM(vmID string) irs.VMInfo {
 func ExtractDescribeInstances(reservation *ec2.Reservation) irs.VMInfo {
 	//cblogger.Info("ExtractDescribeInstances", reservation)
 	cblogger.Debug("Instances[0]", reservation.Instances[0])
-	//cblogger.Info("ImageId : [%s]", *reservation.Instances[0].ImageId)
 
-	//len()
-
-	//"stopped" / "terminated" / "running"
-	//Running 상태에서만 체크 가능한 값
+	//"stopped" / "terminated" / "running" ...
 	var state string
 	state = *reservation.Instances[0].State.Name
 	cblogger.Info("EC2 상태 : [%s]", state)
@@ -446,13 +397,11 @@ func (vmHandler *AwsVMHandler) ListVM() []*irs.VMInfo {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			default:
-				//fmt.Println(aerr.Error())
 				cblogger.Error(aerr.Error())
 				return vmInfoList
 			}
 		} else {
 			// Print the error, cast err to awserr.Error to get the Code and Message from an error.
-			//fmt.Println(err.Error())
 			cblogger.Error(err.Error())
 			return vmInfoList
 		}
@@ -465,7 +414,6 @@ func (vmHandler *AwsVMHandler) ListVM() []*irs.VMInfo {
 		for _, vm := range i.Instances {
 			cblogger.Info("[%s] EC2 정보 조회", *vm.InstanceId)
 			vmInfo := vmHandler.GetVM(*vm.InstanceId)
-			//cblogger.Info(vmStatusInfo.VmId, " EC2 Status : ", vmStatusInfo.VmStatus)
 			vmInfoList = append(vmInfoList, &vmInfo)
 		}
 	}
@@ -491,13 +439,11 @@ func (vmHandler *AwsVMHandler) GetVMStatus(vmID string) irs.VMStatus {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			default:
-				//fmt.Println(aerr.Error())
 				cblogger.Error(aerr.Error())
 				return irs.VMStatus("")
 			}
 		} else {
 			// Print the error, cast err to awserr.Error to get the Code and Message from an error.
-			//fmt.Println(err.Error())
 			cblogger.Error(err.Error())
 			return irs.VMStatus("")
 		}
@@ -531,13 +477,11 @@ func (vmHandler *AwsVMHandler) ListVMStatus() []*irs.VMStatusInfo {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			default:
-				//fmt.Println(aerr.Error())
 				cblogger.Error(aerr.Error())
 				return vmStatusList
 			}
 		} else {
 			// Print the error, cast err to awserr.Error to get the Code and Message from an error.
-			//fmt.Println(err.Error())
 			cblogger.Error(err.Error())
 			return vmStatusList
 		}

--- a/cloud-driver/drivers/aws/resources/VNetworkHandler.go
+++ b/cloud-driver/drivers/aws/resources/VNetworkHandler.go
@@ -8,6 +8,7 @@
 //
 // by powerkim@etri.re.kr, 2019.06.
 
+//VPC 처리
 package resources
 
 import (

--- a/cloud-driver/drivers/aws/resources/VNetworkHandler.go
+++ b/cloud-driver/drivers/aws/resources/VNetworkHandler.go
@@ -1,0 +1,43 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type AwsVNetworkHandler struct {
+	Region idrv.RegionInfo
+	Client *ec2.EC2
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, error) {
+	cblogger.Debug("Start")
+	return nil, nil
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VNetworkReqInfo) (irs.VNetworkInfo, error) {
+	cblogger.Info(vNetworkReqInfo)
+	return irs.VNetworkInfo{}, nil
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) GetVNetwork(vNetworkID string) (irs.VNetworkInfo, error) {
+	cblogger.Info("vNetworkID : [%s]", vNetworkID)
+	//result, err := vNetworkHandler.Client.DescribeKeyPairs(input)
+	return irs.VNetworkInfo{}, nil
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) DeleteVNetwork(vNetworkID string) (bool, error) {
+	cblogger.Info("vNetworkID : [%s]", vNetworkID)
+	return true, nil
+}

--- a/cloud-driver/drivers/aws/resources/VNicHandler.go
+++ b/cloud-driver/drivers/aws/resources/VNicHandler.go
@@ -1,0 +1,38 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
+)
+
+type AwsVNicHandler struct {
+	Region idrv.RegionInfo
+	Client *ec2.EC2
+}
+
+func (vNicHandler *AwsVNicHandler) CreateVNic(vNicReqInfo irs.VNicReqInfo) (irs.VNicInfo, error) {
+	return irs.VNicInfo{}, nil
+}
+
+func (vNicHandler *AwsVNicHandler) ListVNic() ([]*irs.VNicInfo, error) {
+	return nil, nil
+}
+
+func (vNicHandler *AwsVNicHandler) GetVNic(vNicID string) (irs.VNicInfo, error) {
+	return irs.VNicInfo{}, nil
+}
+
+func (vNicHandler *AwsVNicHandler) DeleteVNic(vNicID string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
- VM 정보 조회시 제외 시켰던 Public IP 리턴및 예외처리 추가
- Test_Resources.go의 KeyPair 테스트 프로그램의 키 이름을 yaml 환경 설정 파일에서 가져오도록 수정
- Test_Create.go의 VM Start(생성)시 KeyPair가 없는 경우 KeyPair를 생성해서 VM을 생성하도록 반영
