### PR TITLE
공통 인터페이스 구조체 변경및 핸들러 반영

### DIFF
--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -52,7 +52,43 @@ func handleSecurity() {
 
 	//result, err := handler.GetSecurity(securityId)
 	//result, err := handler.GetSecurity("sg-0320a99e0c1bfcefc")
-	result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
+	//result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
+
+	securityReqInfo := irs.SecurityReqInfo{
+		GroupName:   "sgtest2-mcloub-barista",
+		Description: "this is desc",
+		VpcId:       "vpc-5a837e31",
+		IPPermissions: []*irs.SecurityRuleInfo{ //인바운드 정책 설정
+			{
+				FromPort:   80,
+				ToPort:     80,
+				IPProtocol: "tcp",
+				Cidr:       "0.0.0.0/0",
+			},
+			{
+				FromPort:   8080,
+				ToPort:     8080,
+				IPProtocol: "tcp",
+				Cidr:       "0.0.0.0/0",
+			},
+		},
+		IPPermissionsEgress: []*irs.SecurityRuleInfo{ //아웃바운드 정책 설정
+			{
+				FromPort:   443,
+				ToPort:     443,
+				IPProtocol: "tcp",
+				Cidr:       "0.0.0.0/0",
+			},
+			{
+				FromPort:   9443,
+				ToPort:     9443,
+				IPProtocol: "tcp",
+				Cidr:       "0.0.0.0/0",
+			},
+		},
+	}
+
+	result, err := handler.CreateSecurity(securityReqInfo)
 
 	//result, err := handler.DeleteSecurity(securityId)
 	//result, err := handler.ListSecurity()

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -47,9 +47,11 @@ func handleSecurity() {
 	config := readConfigFile()
 
 	securityId := config.Aws.SecurityGroupID
-	securityId = "sg-0fe21e070f09db954"
+	//cblogger.Infof(securityId)
+	//securityId = "sg-0fe21e070f09db954"
 
 	result, err := handler.GetSecurity(securityId)
+	//result, err := handler.GetSecurity("")
 	//result, err := handler.DeleteSecurity(securityId)
 	if err != nil {
 		cblogger.Infof("보안 그룹 조회 실패 : ", err)

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -47,12 +47,13 @@ func handleSecurity() {
 	config := readConfigFile()
 
 	securityId := config.Aws.SecurityGroupID
-	//cblogger.Infof(securityId)
+	cblogger.Infof(securityId)
 	//securityId = "sg-0fe21e070f09db954"
 
-	result, err := handler.GetSecurity(securityId)
-	//result, err := handler.GetSecurity("")
+	//result, err := handler.GetSecurity(securityId)
+	result, err := handler.GetSecurity("sg-0320a99e0c1bfcefc")
 	//result, err := handler.DeleteSecurity(securityId)
+	//result, err := handler.ListSecurity()
 	if err != nil {
 		cblogger.Infof("보안 그룹 조회 실패 : ", err)
 	} else {

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -33,6 +33,33 @@ func init() {
 	cblog.SetLevel("debug")
 }
 
+// Test SecurityHandler
+func handleSecurity() {
+	cblogger.Debug("Start handler")
+
+	ResourceHandler, err := getResourceHandler("Security")
+	if err != nil {
+		panic(err)
+	}
+
+	handler := ResourceHandler.(irs.SecurityHandler)
+
+	config := readConfigFile()
+
+	securityId := config.Aws.SecurityGroupID
+	securityId = "sg-0fe21e070f09db954"
+
+	result, err := handler.GetSecurity(securityId)
+	//result, err := handler.DeleteSecurity(securityId)
+	if err != nil {
+		cblogger.Infof("보안 그룹 조회 실패 : ", err)
+	} else {
+		cblogger.Info("보안 그룹 조회 결과")
+		//cblogger.Info(result)
+		spew.Dump(result)
+	}
+}
+
 // Test PublicIp
 func handlePublicIP() {
 	cblogger.Debug("Start Publicip Resource Test")
@@ -199,9 +226,11 @@ func handleVNetwork() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-	handleKeyPair()
+	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleVNetwork()	//VPC
+	handleSecurity()
+
 	/*
 		KeyPairHandler, err := setKeyPairHandler()
 		if err != nil {

--- a/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -51,7 +51,9 @@ func handleSecurity() {
 	//securityId = "sg-0fe21e070f09db954"
 
 	//result, err := handler.GetSecurity(securityId)
-	result, err := handler.GetSecurity("sg-0320a99e0c1bfcefc")
+	//result, err := handler.GetSecurity("sg-0320a99e0c1bfcefc")
+	result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
+
 	//result, err := handler.DeleteSecurity(securityId)
 	//result, err := handler.ListSecurity()
 	if err != nil {

--- a/cloud-driver/drivers/aws/resources/KeyPairHandler.go
+++ b/cloud-driver/drivers/aws/resources/KeyPairHandler.go
@@ -14,12 +14,14 @@ type AwsKeyPairHandler struct {
 	Client *ec2.EC2
 }
 
+/*
 // @TODO: KeyPairInfo 리소스 프로퍼티 정의 필요
 type KeyPairInfo struct {
 	Name        string
 	Fingerprint string
 	KeyMaterial string //RSA PRIVATE KEY
 }
+*/
 
 func (keyPairHandler *AwsKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
 	cblogger.Debug("Start ListKey()")
@@ -46,7 +48,7 @@ func (keyPairHandler *AwsKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
 		cblogger.Debugf("%s: %s\n", *pair.KeyName, *pair.KeyFingerprint)
 		keyPairInfo := new(irs.KeyPairInfo)
 		keyPairInfo.Name = *pair.KeyName
-		keyPairInfo.Id = *pair.KeyFingerprint
+		keyPairInfo.Fingerprint = *pair.KeyFingerprint
 
 		keyPairList = append(keyPairList, keyPairInfo)
 	}
@@ -75,19 +77,12 @@ func (keyPairHandler *AwsKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 	cblogger.Infof("Created key pair %q %s\n%s\n", *result.KeyName, *result.KeyFingerprint, *result.KeyMaterial)
 	spew.Dump(result)
 	keyPairInfo := irs.KeyPairInfo{
-		Name: *result.KeyName,
-		Id:   *result.KeyFingerprint,
+		Name:        *result.KeyName,
+		Fingerprint: *result.KeyFingerprint,
+		KeyMaterial: *result.KeyMaterial,
 	}
 
 	return keyPairInfo, nil
-}
-
-func Test() KeyPairInfo {
-	keyPairInfo := KeyPairInfo{
-		Name:        "키이름",
-		Fingerprint: "핑거프린트",
-	}
-	return keyPairInfo
 }
 
 //혼선을 피하기 위해 keyPairID 대신 keyPairName으로 변경 함.
@@ -127,16 +122,10 @@ func (keyPairHandler *AwsKeyPairHandler) GetKey(keyPairName string) (irs.KeyPair
 	cblogger.Info("Fingerprint : ", *result.KeyPairs[0].KeyFingerprint)
 
 	keyPairInfo := irs.KeyPairInfo{
-		Name: *result.KeyPairs[0].KeyName,
-		Id:   *result.KeyPairs[0].KeyFingerprint,
+		Name:        *result.KeyPairs[0].KeyName,
+		Fingerprint: *result.KeyPairs[0].KeyFingerprint,
 	}
 
-	/*
-		keyPairInfo := KeyPairInfo{
-			Name:        *result.KeyPairs[0].KeyName,
-			Fingerprint: *result.KeyPairs[0].KeyFingerprint,
-		}
-	*/
 	return keyPairInfo, nil
 }
 

--- a/cloud-driver/drivers/aws/resources/PublicIPHandler.go
+++ b/cloud-driver/drivers/aws/resources/PublicIPHandler.go
@@ -56,6 +56,7 @@ func (publicIpHandler *AwsPublicIPHandler) CreatePublicIP(publicIPReqInfo irs.Pu
 		cblogger.Errorf("Unable to associate IP address with %s, %v", instanceID, err)
 		return irs.PublicIPInfo{}, err
 	}
+	spew.Dump(assocRes)
 	cblogger.Infof("[%s] EC2에 [%s] IP 할당 완료 - Allocation Id : [%s]", instanceID, *allocRes.PublicIp, *assocRes.AssociationId)
 
 	return irs.PublicIPInfo{}, nil

--- a/cloud-driver/drivers/aws/resources/SecurityHandler.go
+++ b/cloud-driver/drivers/aws/resources/SecurityHandler.go
@@ -11,6 +11,10 @@
 package resources
 
 import (
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	idrv "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources"
@@ -30,9 +34,111 @@ func (securityHandler *AwsSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 }
 
 func (securityHandler *AwsSecurityHandler) GetSecurity(securityID string) (irs.SecurityInfo, error) {
-	return irs.SecurityInfo{}, nil
+	cblogger.Infof("securityID : [%s]", securityID)
+	input := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{
+			aws.String(securityID),
+		},
+	}
+
+	result, err := securityHandler.Client.DescribeSecurityGroups(input)
+	cblogger.Info("result : ", result)
+	cblogger.Info("err : ", err)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return irs.SecurityInfo{}, err
+	}
+
+	var ipPermissions []*irs.SecurityRuleInfo
+	var ipPermissionsEgress []*irs.SecurityRuleInfo
+
+	ipPermissions = ExtractIpPermissions(result.SecurityGroups[0].IpPermissions)
+	cblogger.Info("InBouds : ", ipPermissions)
+	ipPermissionsEgress = ExtractIpPermissions(result.SecurityGroups[0].IpPermissionsEgress)
+	cblogger.Info("OutBounds : ", ipPermissionsEgress)
+	//spew.Dump(ipPermissionsEgress)
+
+	securityInfo := irs.SecurityInfo{
+		GroupName: *result.SecurityGroups[0].GroupName,
+		GroupID:   *result.SecurityGroups[0].GroupId,
+
+		IPPermissions:       ipPermissions,       //AWS:InBounds
+		IPPermissionsEgress: ipPermissionsEgress, //AWS:OutBounds
+
+		Description: *result.SecurityGroups[0].Description,
+		VpcID:       *result.SecurityGroups[0].VpcId,
+		OwnerID:     *result.SecurityGroups[0].OwnerId,
+	}
+
+	//Name은 Tag의 "Name" 속성에만 저장됨
+	cblogger.Debug("Name Tag 찾기")
+	for _, t := range result.SecurityGroups[0].Tags {
+		if *t.Key == "Name" {
+			securityInfo.Name = *t.Value
+			cblogger.Debug("Name : ", securityInfo.Name)
+			break
+		}
+	}
+
+	return securityInfo, nil
+}
+
+func ExtractIpPermissions(ipPermissions []*ec2.IpPermission) []*irs.SecurityRuleInfo {
+
+	var results []*irs.SecurityRuleInfo
+
+	for _, ip := range ipPermissions {
+		cblogger.Info("Inbound 정보 조회 : ", *ip.IpProtocol)
+		securityRuleInfo := new(irs.SecurityRuleInfo)
+
+		if !reflect.ValueOf(ip.FromPort).IsNil() {
+			securityRuleInfo.FromPort = *ip.FromPort
+		}
+
+		if !reflect.ValueOf(ip.ToPort).IsNil() {
+			securityRuleInfo.ToPort = *ip.FromPort
+		}
+
+		securityRuleInfo.IPProtocol = *ip.IpProtocol
+		securityRuleInfo.Cidr = *ip.IpRanges[0].CidrIp
+
+		results = append(results, securityRuleInfo)
+	}
+
+	return results
 }
 
 func (securityHandler *AwsSecurityHandler) DeleteSecurity(securityID string) (bool, error) {
+	cblogger.Infof("securityID : [%s]", securityID)
+
+	// Delete the security group.
+	_, err := securityHandler.Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+		GroupId: aws.String(securityID),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "InvalidGroupId.Malformed":
+				fallthrough
+			case "InvalidGroup.NotFound":
+				cblogger.Errorf("%s.", aerr.Message())
+				return false, err
+			}
+		}
+		cblogger.Errorf("Unable to get descriptions for security groups, %v.", err)
+		return false, err
+	}
+
+	cblogger.Infof("Successfully delete security group %q.", securityID)
+
 	return true, nil
 }

--- a/cloud-driver/interfaces/resources/KeyPairHandler.go
+++ b/cloud-driver/interfaces/resources/KeyPairHandler.go
@@ -17,9 +17,11 @@ type KeyPairReqInfo struct {
 }
 
 type KeyPairInfo struct {
-	Name string
+	Name string // AWS
 	Id   string
 	// @todo
+	Fingerprint string //AWS
+	KeyMaterial string //AWS:RSA PRIVATE KEY
 }
 
 type KeyPairHandler interface {

--- a/cloud-driver/interfaces/resources/KeyPairHandler.go
+++ b/cloud-driver/interfaces/resources/KeyPairHandler.go
@@ -27,6 +27,6 @@ type KeyPairInfo struct {
 type KeyPairHandler interface {
 	CreateKey(keyPairReqInfo KeyPairReqInfo) (KeyPairInfo, error)
 	ListKey() ([]*KeyPairInfo, error)
-	GetKey(keyPairID string) (KeyPairInfo, error)
-	DeleteKey(keyPairID string) (bool, error)
+	GetKey(keyPairID string) (KeyPairInfo, error) // AWS는 keyPairName
+	DeleteKey(keyPairID string) (bool, error)     // AWS는 keyPairName
 }

--- a/cloud-driver/interfaces/resources/KeyPairHandler.go
+++ b/cloud-driver/interfaces/resources/KeyPairHandler.go
@@ -20,8 +20,8 @@ type KeyPairInfo struct {
 	Name string // AWS
 	Id   string
 	// @todo
-	Fingerprint string //AWS
-	KeyMaterial string //AWS:RSA PRIVATE KEY
+	Fingerprint string // 추가 - AWS, OpenStack
+	KeyMaterial string // 추가 - AWS(PEM파일-RSA PRIVATE KEY)
 }
 
 type KeyPairHandler interface {

--- a/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -14,12 +14,29 @@ type SecurityReqInfo struct {
 	Name string
 	Id   string
 	// @todo
+	GroupName string //AWS
+	GroupID   string //AWS
 }
 
 type SecurityInfo struct {
 	Name string
 	Id   string
 	// @todo
+	GroupName           string              //AWS
+	GroupID             string              //AWS
+	IPPermissions       []*SecurityRuleInfo //AWS:InBounds
+	IPPermissionsEgress []*SecurityRuleInfo //AWS:OutBounds
+
+	Description string //AWS
+	VpcID       string //AWS
+	OwnerID     string //AWS, Azure & OpenStack은 TenantId
+}
+
+type SecurityRuleInfo struct {
+	FromPort   int64
+	ToPort     int64
+	IPProtocol string
+	Cidr       string
 }
 
 type SecurityHandler interface {

--- a/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -13,9 +13,14 @@ package resources
 type SecurityReqInfo struct {
 	Name string
 	Id   string
+
 	// @todo
-	GroupName string //AWS
-	GroupID   string //AWS
+	GroupName   string //AWS
+	Description string //AWS
+	VpcId       string //AWS
+
+	IPPermissions       []*SecurityRuleInfo //AWS:InBounds
+	IPPermissionsEgress []*SecurityRuleInfo //AWS:OutBounds
 }
 
 type SecurityInfo struct {

--- a/cloud-driver/interfaces/resources/VMHandler.go
+++ b/cloud-driver/interfaces/resources/VMHandler.go
@@ -56,24 +56,24 @@ type RegionInfo struct {
 }
 
 type VMInfo struct {
-	Name      string
-	Id        string
+	Name      string    // AWS,
+	Id        string    // AWS,
 	StartTime time.Time // Timezone: based on cloud-barista server location.
 
-	Region       RegionInfo // ex) {us-east1, us-east1-c} or {ap-northeast-2}
-	ImageID      string     // ex) ami-047f7b46bd6dd5d84 or projects/gce-uefi-images/global/images/centos-7-v20190326
-	SpecID       string     // instance type or flavour, etc... ex) t2.micro or f1-micro
-	VNetworkID   string     // ex) vpc-23ed0a4b
-	SubNetworkID string     // ex) subnet-8c4a53e4
-	SecurityID   string     // ex) sg-0b7452563e1121bb6
+	Region       RegionInfo // AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
+	ImageID      string     // AWS, ex) ami-047f7b46bd6dd5d84 or projects/gce-uefi-images/global/images/centos-7-v20190326
+	SpecID       string     // AWS, instance type or flavour, etc... ex) t2.micro or f1-micro
+	VNetworkID   string     // AWS, ex) vpc-23ed0a4b
+	SubNetworkID string     // AWS, ex) subnet-8c4a53e4
+	SecurityID   string     // AWS, ex) sg-0b7452563e1121bb6 - @todo AWS는 배열임
 
 	VNIC       string // ex) eth0
-	PublicIP   string // ex) 13.125.43.21
-	PublicDNS  string // ex) ec2-13-125-43-0.ap-northeast-2.compute.amazonaws.com
-	PrivateIP  string // ex) ip-172-31-4-60.ap-northeast-2.compute.internal
-	PrivateDNS string // ex) 172.31.4.60
+	PublicIP   string // ex) AWS, 13.125.43.21
+	PublicDNS  string // ex) AWS, ec2-13-125-43-0.ap-northeast-2.compute.amazonaws.com
+	PrivateIP  string // ex) AWS, ip-172-31-4-60.ap-northeast-2.compute.internal
+	PrivateDNS string // ex) AWS, 172.31.4.60
 
-	KeyPairID    string // ex) powerkimKeyPair
+	KeyPairID    string // ex) AWS, powerkimKeyPair
 	GuestUserID  string // ex) user1
 	GuestUserPwd string
 


### PR DESCRIPTION
개발및 프로바이더별 특성을 반영하기 위해 공통 인터페이스의 구조체에 필요한 필드들 추가 했음.
- 공통 인터페이스 구조체 변경
	- github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources/KeyPairHandler.go
	- github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources/VMHandler.go
	- github.com/cloud-barista/poc-cb-spider/cloud-driver/interfaces/resources/SecurityHandler.go

- VMHandler 완료
- KeyPairHandler 완료
- SecurityHandler 완료